### PR TITLE
Remove splatfactow_config to avoid nerfstudio problem

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,5 @@ include = ["splatfactow*", "splatfactow_light*"]
 
 # register the entry point of your new method here:
 [project.entry-points.'nerfstudio.method_configs']
-splatfactow = 'splatfactow.splatfactow_config:splatfactow_config'
+# splatfactow = 'splatfactow.splatfactow_config:splatfactow_config'
 splatfactow_light = 'splatfactow.splatfactow_config:splatfactow_light_config'


### PR DESCRIPTION
See https://github.com/KevinXu02/splatfacto-w/issues/18

This disables the registration of splatfactow, and keeps `splatfacto-w-light`, which we use.  This should likely fix the problem.  

Although it's covered in the issue, here's the error when we run this command:
```
ns-train splatfacto-w-light --data ...
```
Error:
```
AssertionError: pipeline.datamanager.dataparser was provided a default value of type <class 'splatfactow.nerfw_dataparser.NerfWDataParserConfig'> but no matching subcommand was found. A type may be missing in the Union type declaration for pipeline.datamanager.dataparser, which currently expects [typing.Annotated[nerfstudio.data.dataparsers.nerfstudio_dataparser.NerfstudioDataParserConfig, _SubcommandConfiguration(name='nerfstudio-data', default=NerfstudioDataParserConfig(_target=<class 
...
```